### PR TITLE
creates symlink in postinst

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,6 @@
 MAINTAINER = "CS50 <sysadmins@cs50.harvard.edu>"
 NAME = phpliteadmin
-VERSION = 1.2.1
+VERSION = 1.2.2
 
 .PHONY: bash
 bash:
@@ -13,14 +13,10 @@ build:
 
 .PHONY: clean
 clean:
-	rm -f opt/cs50/bin/phpliteadmin
-	rmdir --ignore-fail-on-non-empty -p opt/cs50/bin/ &>/dev/null
 	rm -f $(NAME)_$(VERSION)_*.deb
 
 .PHONY: deb
 deb: clean
-	mkdir -p opt/cs50/bin/
-	ln -s /opt/cs50/phpliteadmin/bin/phpliteadmin -t opt/cs50/bin/
 	chmod -R a+rX opt
 	chmod -R a+x opt/cs50/phpliteadmin/bin/*
 	fpm \
@@ -29,6 +25,7 @@ deb: clean
 	-s dir \
 	-t deb \
 	-v $(VERSION) \
+	--after-install postinst \
 	--deb-no-default-config-files \
 	--depends coreutils \
 	--depends curl \

--- a/postinst
+++ b/postinst
@@ -1,0 +1,2 @@
+mkdir -p /opt/cs50/bin/
+ln -s /opt/cs50/phpliteadmin/bin/phpliteadmin -t opt/cs50/bin/

--- a/postinst
+++ b/postinst
@@ -1,2 +1,2 @@
 mkdir -p /opt/cs50/bin/
-ln -s /opt/cs50/phpliteadmin/bin/phpliteadmin -t opt/cs50/bin/
+ln -sf /opt/cs50/phpliteadmin/bin/phpliteadmin -t /opt/cs50/bin/


### PR DESCRIPTION
After more testing, particularly of the "upgrading" scenario (i.e., upgrading v1.1.1 to v1.2.1), turns out `/opt/cs50/bin/phpliteadmin`, which is packaged as symlink to `/opt/cs50/phpliteadmin/bin/phpliteadmin` in v1.2.1, is not there.

Traced the problem and apparently this is because v1.1.1's `postrm` maintainer script runs after v1.2.1's files are unpacked on the system, causing the symlink to get removed per [v1.1.1's `after-remove.sh`#L4](https://github.com/cs50/phpliteadmin/blob/03f4791fa71add613311b812c758c0d30919370c/after-remove.sh#L4).

The illustration below from [Debian Wiki](https://wiki.debian.org/MaintainerScripts#Upgrading) confirms that:

![](https://wiki.debian.org/MaintainerScripts?action=AttachFile&do=get&target=upgrade.png)
